### PR TITLE
ci: use node@20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-20.04, windows-latest ]
-        node-version: [ 16 ]
+        node-version: [ 20 ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Updates CI to use Node@20, cf. https://github.com/bpmn-io/internal-docs/issues/818.