### PR TITLE
chore: bump sinon-chai to v4 for chai 6 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "puppeteer": "^24.0.0",
         "rollup": "^4.22.4",
         "sinon": "^21.0.0",
-        "sinon-chai": "^3.7.0",
+        "sinon-chai": "^4.0.0",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -2927,6 +2927,8 @@
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
+      "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
       "cpu": [
         "x64"
       ],
@@ -11741,11 +11743,13 @@
       }
     },
     "node_modules/sinon-chai": {
-      "version": "3.7.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-4.0.1.tgz",
+      "integrity": "sha512-xMKEEV3cYHC1G+boyr7QEqi80gHznYsxVdC9CdjP5JnCWz/jPGuXQzJz3PtBcb0CcHAxar15Y5sjLBoAs6a0yA==",
       "dev": true,
       "license": "(BSD-2-Clause OR WTFPL)",
       "peerDependencies": {
-        "chai": "^4.0.0",
+        "chai": "^5.0.0 || ^6.0.0",
         "sinon": ">=4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "puppeteer": "^24.0.0",
     "rollup": "^4.22.4",
     "sinon": "^21.0.0",
-    "sinon-chai": "^3.7.0",
+    "sinon-chai": "^4.0.0",
     "typescript": "^4.9.5"
   },
   "workspaces": {


### PR DESCRIPTION
Follow-up to #44. That PR landed chai 6 and sinon 21, but left `sinon-chai` at 3.7.0 whose peer dep is `chai@^4`. The install only worked because we were silently relying on `--legacy-peer-deps`. Any fresh `npm ci` in an unforgiving environment would fail.

`sinon-chai@4.0.1` peer-depends on `chai@^5.0.0 || ^6.0.0` and `sinon >=4.0.0`, which satisfies our current stack. The assertion sugar we actually use (`expect(fn).to.have.been.calledOnce`, `.calledWith(...)`) is unchanged across the major bump, so this is a drop-in from our test suite's perspective.

Verified locally:
- `npm install` without `--legacy-peer-deps` — clean resolution
- `npm test` — 76 passing
- `npm run lint` — clean