### PR TITLE
test: migrate to explicit chai / sinon imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,24 +116,8 @@ export default [
     languageOptions: {
       parserOptions: {
         ...baseParserOptions,
-        sourceType: 'commonjs'
       },
       globals: {
-        require: 'readonly'
-      }
-    }
-  },
-  {
-    files: [
-      'test/testSetup.js'
-    ],
-    languageOptions: {
-      parserOptions: {
-        ...baseParserOptions,
-        sourceType: 'commonjs'
-      },
-      globals: {
-        ...globals.browser,
         require: 'readonly'
       }
     }

--- a/test/spec/editor.spec.js
+++ b/test/spec/editor.spec.js
@@ -1,3 +1,6 @@
+import { expect } from 'chai';
+import { spy, match } from 'sinon';
+
 import { FeelersEditor } from '../../src';
 import TestContainer from 'mocha-test-container-support';
 import { EditorSelection } from '@codemirror/state';
@@ -344,7 +347,7 @@ describe.skip('CodeEditor', function() {
     it('should call onChange', async function() {
 
       // given
-      const onChange = sinon.spy();
+      const onChange = spy();
       const editor = new FeelEditor({
         container,
         onChange
@@ -368,7 +371,7 @@ describe.skip('CodeEditor', function() {
     it('should call onKeyDown', async function() {
 
       // given
-      const onKeyDown = sinon.spy();
+      const onKeyDown = spy();
       const editor = new FeelEditor({
         container,
         onKeyDown
@@ -459,7 +462,7 @@ describe.skip('CodeEditor', function() {
 
     it('should call onLint with errors', function(done) {
       const initalValue = '= 15';
-      const onLint = sinon.spy();
+      const onLint = spy();
 
       const editor = new FeelEditor({
         container,
@@ -477,7 +480,7 @@ describe.skip('CodeEditor', function() {
       setTimeout(() => {
 
         expect(onLint).to.have.been.calledOnce;
-        expect(onLint).to.have.been.calledWith(sinon.match.array);
+        expect(onLint).to.have.been.calledWith(match.array);
         expect(onLint.args[0][0]).to.have.length(1);
 
         done();
@@ -488,7 +491,7 @@ describe.skip('CodeEditor', function() {
 
     it('should call onLint without errors', function(done) {
       const initalValue = '15';
-      const onLint = sinon.spy();
+      const onLint = spy();
 
       const editor = new FeelEditor({
         container,
@@ -506,7 +509,7 @@ describe.skip('CodeEditor', function() {
       setTimeout(() => {
 
         expect(onLint).to.have.been.calledOnce;
-        expect(onLint).to.have.been.calledWith(sinon.match.array);
+        expect(onLint).to.have.been.calledWith(match.array);
         expect(onLint.args[0][0]).to.have.length(0);
 
         done();

--- a/test/spec/interpreter.spec.js
+++ b/test/spec/interpreter.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 const ERROR_CHAR = '⚠';
 
+
 describe('interpreter', () => {
 
   describe('simple inputs', () => {

--- a/test/spec/parser.spec.js
+++ b/test/spec/parser.spec.js
@@ -1,5 +1,7 @@
-import { buildSimpleTree, parser } from '../../src/grammar';
 import { expect } from 'chai';
+
+import { buildSimpleTree, parser } from '../../src/grammar';
+
 
 describe('parser', () => {
 

--- a/test/spec/singleStart.spec.js
+++ b/test/spec/singleStart.spec.js
@@ -1,9 +1,12 @@
+import { expect } from 'chai';
+
 import TestContainer from 'mocha-test-container-support';
 import { FeelersEditor } from '../../src';
 import { evaluate } from '../../src/interpreter';
 import { initialContext, initialTemplate } from '../testData';
 
 const singleStart = window.__env__ && window.__env__.SINGLE_START;
+
 
 describe('CodeEditor', function() {
 

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,20 +1,4 @@
-const chaiNamespace = require('chai');
-const sinonNamespace = require('sinon');
-const sinonChaiNamespace = require('sinon-chai');
+import { use as chaiUse } from 'chai';
+import sinonChai from 'sinon-chai';
 
-const chai = chaiNamespace.expect ? chaiNamespace : chaiNamespace.default;
-const sinon = sinonNamespace.default || sinonNamespace;
-const sinonChai = sinonChaiNamespace.default || sinonChaiNamespace;
-
-chai.use(sinonChai);
-
-const root = typeof window !== 'undefined' ? window : globalThis;
-
-root.chai = chai;
-root.expect = chai.expect;
-root.assert = chai.assert;
-root.sinon = sinon;
-
-if (typeof chai.should === 'function') {
-  root.should = chai.should();
-}
+chaiUse(sinonChai);


### PR DESCRIPTION
### Proposed Changes

Remove the hack we employed to make `chai` globally available - follow bpmn.io pattern, use as explicit import (https://github.com/bpmn-io/internal-docs/issues/972).

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
