### PR TITLE
fix: restore syntax highlighting with @bpmn-io/cm-theme@0.2.1+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@bpmn-io/cm-theme": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.2.0.tgz",
-      "integrity": "sha512-uWrOWvABxvP+6g7tjVbjBXLywWe4e1uZaqQCJfm+RHxwYFRzPWDnpsn+7AMiAfCNDk8jXUDPqpnQXv93Mq6M0Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.2.2.tgz",
+      "integrity": "sha512-9mD7fzzNDNBgseOUC6iRX4mi17LIO2es4zkcHt4e4owQC2Q3YPvqJTJaXqc7kkItloSFsqG2j/1iMJkpvjLv2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6732,13 +6732,13 @@
         "mitt": "^3.0.1"
       },
       "devDependencies": {
-        "@bpmn-io/cm-theme": "0.2.0",
+        "@bpmn-io/cm-theme": "0.2.2",
         "cross-env": "^10.1.0",
         "marked": "^18.0.5",
         "mocha-test-container-support": "^0.2.0"
       },
       "peerDependencies": {
-        "@bpmn-io/cm-theme": "^0.2.0"
+        "@bpmn-io/cm-theme": "^0.2.1"
       }
     },
     "packages/feelers-lint": {

--- a/packages/feelers-editor/CHANGELOG.md
+++ b/packages/feelers-editor/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [@bpmn-io/feelers-editor](https://github.com/bpmn-io/feel
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: restore syntax highlighting with `@bpmn-io/cm-theme@0.2.1+` ([#117](https://github.com/bpmn-io/feelers/pull/117))
+
 ## 1.1.0
 
 * `FEAT`: syntax highlight HTML in markdown mode ([#110](https://github.com/bpmn-io/feelers/pull/110))

--- a/packages/feelers-editor/package.json
+++ b/packages/feelers-editor/package.json
@@ -55,12 +55,12 @@
     "mitt": "^3.0.1"
   },
   "devDependencies": {
-    "@bpmn-io/cm-theme": "0.2.0",
+    "@bpmn-io/cm-theme": "^0.2.2",
     "cross-env": "^10.1.0",
     "marked": "^18.0.5",
     "mocha-test-container-support": "^0.2.0"
   },
   "peerDependencies": {
-    "@bpmn-io/cm-theme": "^0.2.0"
+    "@bpmn-io/cm-theme": "^0.2.1"
   }
 }


### PR DESCRIPTION
@bpmn-io/cm-theme@0.2.0 was missing token styles for feelers delimiters, FEEL variables, and operators. Bump devDep to 0.2.2 and tighten peerDep minimum to ^0.2.1 where the fix landed.

<img width="3816" height="2032" alt="image" src="https://github.com/user-attachments/assets/c8dcdb75-e86b-4033-ad2d-4a4b5c3eecea" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
